### PR TITLE
CHALLENGER njit serial numpy dot

### DIFF
--- a/sdp/challenger_sdp.py
+++ b/sdp/challenger_sdp.py
@@ -1,14 +1,18 @@
 import numpy as np
+from numba import njit
 
 
 def setup(Q, T):
+    sliding_dot_product(Q, T)
     return
 
 
+@njit(fastmath=True)
 def sliding_dot_product(Q, T):
-    m = len(Q)
+    m = Q.shape[0]
     l = T.shape[0] - m + 1
     out = np.empty(l)
     for i in range(l):
         out[i] = np.dot(Q, T[i : i + m])
+
     return out


### PR DESCRIPTION
Tested the `njit` `dot` function from `numpy`:

```
import numpy as np
from numba import njit


def setup(Q, T):
    sliding_dot_product(Q, T)
    return


@njit(fastmath=True)
def sliding_dot_product(Q, T):
    m = Q.shape[0]
    l = T.shape[0] - m + 1
    out = np.empty(l)
    for i in range(l):
        out[i] = np.dot(Q, T[i : i + m])

    return out
```

Using ./test.py -noheader -pmin 6 -pmax 23 -pdiff 6 challenger >> timing.csv.

![download-29](https://github.com/user-attachments/assets/d2ca91d9-5316-49a5-82b9-0328113356dd)
