### PR TITLE
CHALLENGER njit parallel numpy dot

### DIFF
--- a/sdp/challenger_sdp.py
+++ b/sdp/challenger_sdp.py
@@ -1,14 +1,18 @@
 import numpy as np
+from numba import njit, prange
 
 
 def setup(Q, T):
+    sliding_dot_product(Q, T)
     return
 
 
+@njit(fastmath=True,parallel=True)
 def sliding_dot_product(Q, T):
-    m = len(Q)
+    m = Q.shape[0]
     l = T.shape[0] - m + 1
     out = np.empty(l)
-    for i in range(l):
+    for i in prange(l):
         out[i] = np.dot(Q, T[i : i + m])
+
     return out


### PR DESCRIPTION
Tested the parallel njit dot function from numpy:

```
import numpy as np
from numba import njit, prange


def setup(Q, T):
    sliding_dot_product(Q, T)
    return


@njit(fastmath=True,parallel=True)
def sliding_dot_product(Q, T):
    m = Q.shape[0]
    l = T.shape[0] - m + 1
    out = np.empty(l)
    for i in prange(l):
        out[i] = np.dot(Q, T[i : i + m])

    return out
```

Using ./test.py -noheader -pmin 6 -pmax 23 -pdiff 6 challenger >> timing.csv

![download-30](https://github.com/user-attachments/assets/4d2cd34c-00a6-487f-ab4c-034dade16e02)
