### PR TITLE
CHALLENGER RocketFFT

### DIFF
--- a/sdp/challenger_sdp.py
+++ b/sdp/challenger_sdp.py
@@ -1,14 +1,22 @@
 import numpy as np
+from scipy.fft import next_fast_len
+from numba import njit
 
 
 def setup(Q, T):
-    return
+    return sliding_dot_product(Q, T)
 
 
+@njit
 def sliding_dot_product(Q, T):
+    n = len(T)
     m = len(Q)
-    l = T.shape[0] - m + 1
-    out = np.empty(l)
-    for i in range(l):
-        out[i] = np.dot(Q, T[i : i + m])
-    return out
+    shape = next_fast_len(n)
+
+    tmp = np.empty((2, shape))
+    tmp[0, :m] = Q[::-1]
+    tmp[0, m:] = 0.0
+    tmp[1, :] = T
+    fft_2d = np.fft.rfft(tmp, axis=-1)
+    
+    return np.fft.irfft(np.multiply(fft_2d[0], fft_2d[1]))[m - 1:n]

--- a/sdp/challenger_sdp.py
+++ b/sdp/challenger_sdp.py
@@ -1,22 +1,14 @@
 import numpy as np
-from scipy.fft import next_fast_len
-from numba import njit
 
 
 def setup(Q, T):
-    return  sliding_dot_product(Q, T)
+    return
 
 
-@njit
 def sliding_dot_product(Q, T):
-    n = len(T)
     m = len(Q)
-    shape = next_fast_len(n)
-
-    tmp = np.empty((2, shape))
-    tmp[0, :m] = Q[::-1]
-    tmp[0, m:] = 0.0
-    tmp[1, :] = T
-    fft_2d = np.fft.rfft(tmp, axis=-1)
-    
-    return np.fft.irfft(np.multiply(fft_2d[0], fft_2d[1]))[m - 1:n]
+    l = T.shape[0] - m + 1
+    out = np.empty(l)
+    for i in range(l):
+        out[i] = np.dot(Q, T[i : i + m])
+    return out

--- a/sdp/challenger_sdp.py
+++ b/sdp/challenger_sdp.py
@@ -1,14 +1,22 @@
 import numpy as np
+from scipy.fft import next_fast_len
+from numba import njit
 
 
 def setup(Q, T):
-    return
+    return  sliding_dot_product(Q, T)
 
 
+@njit
 def sliding_dot_product(Q, T):
+    n = len(T)
     m = len(Q)
-    l = T.shape[0] - m + 1
-    out = np.empty(l)
-    for i in range(l):
-        out[i] = np.dot(Q, T[i : i + m])
-    return out
+    shape = next_fast_len(n)
+
+    tmp = np.empty((2, shape))
+    tmp[0, :m] = Q[::-1]
+    tmp[0, m:] = 0.0
+    tmp[1, :] = T
+    fft_2d = np.fft.rfft(tmp, axis=-1)
+    
+    return np.fft.irfft(np.multiply(fft_2d[0], fft_2d[1]))[m - 1:n]


### PR DESCRIPTION
Tested RocketFFT:

```
import numpy as np
from scipy.fft import next_fast_len
from numba import njit


def setup(Q, T):
    return sliding_dot_product(Q, T)


@njit
def sliding_dot_product(Q, T):
    n = len(T)
    m = len(Q)
    shape = next_fast_len(n)

    tmp = np.empty((2, shape))
    tmp[0, :m] = Q[::-1]
    tmp[0, m:] = 0.0
    tmp[1, :] = T
    fft_2d = np.fft.rfft(tmp, axis=-1)

    return np.fft.irfft(np.multiply(fft_2d[0], fft_2d[1]))[m - 1:n]
```

./test.py -noheader -pmin 6 -pmax 23 -pdiff 9 challenger >> timing.csv

![download-39](https://github.com/user-attachments/assets/e0694096-af02-4f0f-b0ac-70999c5873ca)
