### PR TITLE
Fixed #26 Use less-aggressive planning flag as default

### DIFF
--- a/matlab_sdp.m
+++ b/matlab_sdp.m
@@ -5,7 +5,7 @@
 % See MASS_V2 here: https://www.cs.unm.edu/~mueen/FastestSimilaritySearch.html
 % MASS_V2 is used in [DAMP_2_0.m](https://drive.google.com/file/d/1EPDhFXQ2goTJ5m_x1S84-KNpQFsRNVmf/view?usp=sharing)
 
-function [z] = MASS_SDP(Q, T)
+function [z] = fft_sdp(Q, T)
     % Input:
     %   Q - query vector
     %   T - time series vector
@@ -16,7 +16,7 @@ function [z] = MASS_SDP(Q, T)
     n = length(T);
 
     Q = Q(end:-1:1);  % Reverse the query
-    Q(m+1:n) = 0;  % Aappend zeros
+    Q(m+1:n) = 0;  % Append zeros
 
     X = fft(T);
     Y = fft(Q);

--- a/matlab_sdp.m
+++ b/matlab_sdp.m
@@ -1,9 +1,9 @@
 % This function computes the sliding dot product between
 % a query Q and a time series T using the FFT method.
 
-%See TABLE I (old) here: https://www.cs.ucr.edu/~eamonn/PID4481997_extend_Matrix%20Profile_I.pdf
-%See MASS_V2 here: https://www.cs.unm.edu/~mueen/FastestSimilaritySearch.html
-%MASS_V2 is used in [DAMP_2_0.m](https://drive.google.com/file/d/1EPDhFXQ2goTJ5m_x1S84-KNpQFsRNVmf/view?usp=sharing)
+% See TABLE I (old) here: https://www.cs.ucr.edu/~eamonn/PID4481997_extend_Matrix%20Profile_I.pdf
+% See MASS_V2 here: https://www.cs.unm.edu/~mueen/FastestSimilaritySearch.html
+% MASS_V2 is used in [DAMP_2_0.m](https://drive.google.com/file/d/1EPDhFXQ2goTJ5m_x1S84-KNpQFsRNVmf/view?usp=sharing)
 
 function [z] = MASS_SDP(Q, T)
     % Input:

--- a/matlab_sdp.m
+++ b/matlab_sdp.m
@@ -1,0 +1,27 @@
+% This function computes the sliding dot product between
+% a query Q and a time series T using the FFT method.
+
+%See TABLE I (old) here: https://www.cs.ucr.edu/~eamonn/PID4481997_extend_Matrix%20Profile_I.pdf
+%See MASS_V2 here: https://www.cs.unm.edu/~mueen/FastestSimilaritySearch.html
+%MASS_V2 is used in [DAMP_2_0.m](https://drive.google.com/file/d/1EPDhFXQ2goTJ5m_x1S84-KNpQFsRNVmf/view?usp=sharing)
+
+function [z] = MASS_SDP(Q, T)
+    % Input:
+    %   Q - query vector
+    %   T - time series vector
+    % Output:
+    %   z - sliding dot product of Q and T
+
+    m = length(Q);
+    n = length(T);
+
+    Q = Q(end:-1:1);  % Reverse the query
+    Q(m+1:n) = 0;  % Aappend zeros
+
+    X = fft(T);
+    Y = fft(Q);
+    Z = X.*Y;
+    z = ifft(Z);
+    z = z(m:n);
+
+end

--- a/sdp/pyfftw_sdp.py
+++ b/sdp/pyfftw_sdp.py
@@ -98,7 +98,7 @@ class SLIDING_DOT_PRODUCT:
         # RFFT(Q)
         # Scale by 1/next_fast_n to account for
         # FFTW's unnormalized inverse FFT via execute()
-        real_arr[:m] = Q[::-1] / next_fast_n
+        np.multiply(Q[::-1], 1.0 / next_fast_n, out=real_arr[:m])
         real_arr[m:] = 0.0
         rfft_obj.execute()  # output is in complex_arr
 

--- a/sdp/pyfftw_sdp.py
+++ b/sdp/pyfftw_sdp.py
@@ -21,7 +21,7 @@ class SLIDING_DOT_PRODUCT:
         self.rfft_objects = {}
         self.irfft_objects = {}
 
-    def __call__(self, Q, T, n_threads=1, planning_flag="FFTW_MEASURE"):
+    def __call__(self, Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE"):
         """
         Compute the sliding dot product between `Q` and `T` using FFTW via pyfftw.
 
@@ -114,10 +114,10 @@ class SLIDING_DOT_PRODUCT:
 _sliding_dot_product = SLIDING_DOT_PRODUCT()
 
 
-def setup(Q, T, n_threads=1, planning_flag="FFTW_MEASURE"):
+def setup(Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE"):
     _sliding_dot_product(Q, T, n_threads=n_threads, planning_flag=planning_flag)
     return
 
 
-def sliding_dot_product(Q, T, n_threads=1, planning_flag="FFTW_MEASURE"):
+def sliding_dot_product(Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE"):
     return _sliding_dot_product(Q, T, n_threads=n_threads, planning_flag=planning_flag)


### PR DESCRIPTION
This PR is to address #26. The goal is to use less-aggressive planning flag for FFTW. 

---

As mentioned in https://github.com/stumpy-dev/sliding_dot_product/issues/26#issuecomment-3688172678, [MATLAB takes a similar approach by default](https://www.mathworks.com/help/matlab/ref/fftw.html):

> Description
[method](https://www.mathworks.com/help/matlab/ref/fftw.html#bvjhb5d-1-method) = fftw('planner') returns the method that the fast Fourier transform functions fft, fft2, fftn, ifft, ifft2, and ifftn use to determine a transform algorithm. The **default method is 'estimate',** which determines the algorithm based on the size of the data.