### PR TITLE
Change variable name from `shape` to `next_fast_n`

### DIFF
--- a/sdp/numpy_fft_sdp.py
+++ b/sdp/numpy_fft_sdp.py
@@ -9,13 +9,13 @@ def setup(Q, T):
 def sliding_dot_product(Q, T, order="F"):
     n = len(T)
     m = len(Q)
-    shape = next_fast_len(n, real=True)
+    next_fast_n = next_fast_len(n, real=True)
 
-    tmp = np.empty((2, shape), order=order)
+    tmp = np.empty((2, next_fast_n), order=order)
     tmp[0, :m] = Q[::-1]
     tmp[0, m:] = 0.0
     tmp[1, :n] = T
     tmp[1, n:] = 0.0
     fft_2d = np.fft.rfft(tmp, axis=-1)
 
-    return np.fft.irfft(np.multiply(fft_2d[0], fft_2d[1]), n=shape)[m - 1 : n]
+    return np.fft.irfft(np.multiply(fft_2d[0], fft_2d[1]), n=next_fast_n)[m - 1 : n]

--- a/sdp/pocketfft_r2c_c2r_sdp.py
+++ b/sdp/pocketfft_r2c_c2r_sdp.py
@@ -10,13 +10,13 @@ def setup(Q, T):
 def sliding_dot_product(Q, T):
     n = len(T)
     m = len(Q)
-    shape = next_fast_len(n, real=True)
+    next_fast_n = next_fast_len(n, real=True)
 
-    tmp = np.empty((2, shape))
+    tmp = np.empty((2, next_fast_n))
     tmp[0, :m] = Q[::-1]
     tmp[0, m:] = 0.0
     tmp[1, :n] = T
     tmp[1, n:] = 0.0
     fft_2d = r2c(True, tmp, axis=-1)
 
-    return c2r(False, np.multiply(fft_2d[0], fft_2d[1]), n=shape)[m - 1 : n]
+    return c2r(False, np.multiply(fft_2d[0], fft_2d[1]), n=next_fast_n)[m - 1 : n]


### PR DESCRIPTION
To be consistent with [pyfftw_sdp.py](https://github.com/stumpy-dev/sliding_dot_product/blob/main/sdp/pyfftw_sdp.py), I've changed the variable name from `shape` to `next_fast_n` in other modules.